### PR TITLE
Support requirements.txt as file names

### DIFF
--- a/pip-requirements.el
+++ b/pip-requirements.el
@@ -37,6 +37,8 @@
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.pip\\'" . pip-requirements-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("requirements\\.txt\\'" . pip-requirements-mode))
 
 (defconst pip-requirements-name-regex
   (rx


### PR DESCRIPTION
Add `requirements.txt` to `auto-mode-alist`.

`requirements.txt` and variations thereof (e.g. `production-requirements.txt`) are much more common than `.pip`.  As a matter of fact, I have never seen a `.pip` file in years of Python programming.  Where did you see this extension?

Thank you for this mode!
