### PR TITLE
Replace cdddr with cdr

### DIFF
--- a/pip-requirements.el
+++ b/pip-requirements.el
@@ -89,7 +89,7 @@
             ;; Get the body tag.
             -last-item
             ;; Immediate children of the body.
-            cdddr
+            cdr cdr cdr
             ;; Anchor tags.
             (--filter (eq (car it) 'a))
             ;; Inner text of anchor tags.


### PR DESCRIPTION
cdddr comes from cl, and would need (require 'cl).

Alternatively, we could use cl-cdddr from cl-lib, but we'd need to add cl-lib to Package-Requires then.
