### PR TITLE
define ‘<’, ‘>’, and ‘=’ as punctuation in syntax table

### DIFF
--- a/pip-requirements.el
+++ b/pip-requirements.el
@@ -86,6 +86,9 @@
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?# "<" table)
     (modify-syntax-entry ?\n ">" table)
+    (modify-syntax-entry ?> "." table)
+    (modify-syntax-entry ?< "." table)
+    (modify-syntax-entry ?= "." table)
     table))
 
 (defvar pip-http-buffer nil)


### PR DESCRIPTION
This will make things like `symbol-at-point` work correctly.
Before this change, `symbol-at-point` for ‘packa|ge==1.0.0’
(the | is the cursor) will return ‘package==’; after this
change it will return ‘package’, as intended.